### PR TITLE
Update to openvino 2025

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,8 +513,7 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 [[package]]
 name = "openvino"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f03a664ab0b6917131f5c1a787795fa4d19ad6a334caf9c96284453abdf23fd"
+source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=b590f0fe2467c52b74ef4e9a636ba79b9e6a693f#b590f0fe2467c52b74ef4e9a636ba79b9e6a693f"
 dependencies = [
  "openvino-finder",
  "openvino-sys",
@@ -523,8 +522,7 @@ dependencies = [
 [[package]]
 name = "openvino-finder"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d6bbb3e00d9ad3cd60bca1341665a9cfb2b6764df37c58d921627368ae32fc"
+source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=b590f0fe2467c52b74ef4e9a636ba79b9e6a693f#b590f0fe2467c52b74ef4e9a636ba79b9e6a693f"
 dependencies = [
  "cfg-if",
  "log",
@@ -533,8 +531,7 @@ dependencies = [
 [[package]]
 name = "openvino-sys"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04315994236727c3573f7e8d8bf857e93ff373ee2e063f08aa78aceac58e3bc5"
+source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=b590f0fe2467c52b74ef4e9a636ba79b9e6a693f#b590f0fe2467c52b74ef4e9a636ba79b9e6a693f"
 dependencies = [
  "env_logger",
  "libloading",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,7 +472,7 @@ dependencies = [
 
 [[package]]
 name = "ml-bench"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -512,8 +512,8 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openvino"
-version = "0.8.0"
-source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=b590f0fe2467c52b74ef4e9a636ba79b9e6a693f#b590f0fe2467c52b74ef4e9a636ba79b9e6a693f"
+version = "0.9.0"
+source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=eef188a4f0fd52020bfe95822ead35f37ee4efaf#eef188a4f0fd52020bfe95822ead35f37ee4efaf"
 dependencies = [
  "openvino-finder",
  "openvino-sys",
@@ -521,8 +521,8 @@ dependencies = [
 
 [[package]]
 name = "openvino-finder"
-version = "0.8.0"
-source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=b590f0fe2467c52b74ef4e9a636ba79b9e6a693f#b590f0fe2467c52b74ef4e9a636ba79b9e6a693f"
+version = "0.9.0"
+source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=eef188a4f0fd52020bfe95822ead35f37ee4efaf#eef188a4f0fd52020bfe95822ead35f37ee4efaf"
 dependencies = [
  "cfg-if",
  "log",
@@ -530,8 +530,8 @@ dependencies = [
 
 [[package]]
 name = "openvino-sys"
-version = "0.8.0"
-source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=b590f0fe2467c52b74ef4e9a636ba79b9e6a693f#b590f0fe2467c52b74ef4e9a636ba79b9e6a693f"
+version = "0.9.0"
+source = "git+https://github.com/Rickvanderveen/openvino-rs.git?rev=eef188a4f0fd52020bfe95822ead35f37ee4efaf#eef188a4f0fd52020bfe95822ead35f37ee4efaf"
 dependencies = [
  "env_logger",
  "libloading",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,6 @@ pedantic = { level = "warn", priority = -1 }
 clap = { version = "4.5.26", features = ["derive"] }
 criterion = "0.5.1"
 miette = { version = "7.2.0", features = ["fancy"] }
-openvino = { git = "https://github.com/Rickvanderveen/openvino-rs.git", rev = "b590f0fe2467c52b74ef4e9a636ba79b9e6a693f", features = [
+openvino = { git = "https://github.com/Rickvanderveen/openvino-rs.git", rev = "eef188a4f0fd52020bfe95822ead35f37ee4efaf", features = [
   "runtime-linking",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ml-bench"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Gijs de Jong <gijs@dutchnaoteam.nl>"]
 description = "A tool for benchmarking inference time of onnx models using the OpenVINO runtime."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,6 @@ pedantic = { level = "warn", priority = -1 }
 clap = { version = "4.5.26", features = ["derive"] }
 criterion = "0.5.1"
 miette = { version = "7.2.0", features = ["fancy"] }
-openvino = { version = "0.8", features = ["runtime-linking"] }
+# openvino = { version = "0.8", features = ["runtime-linking"] }
+openvino = { git = "https://github.com/Rickvanderveen/openvino-rs.git", rev = "b590f0fe2467c52b74ef4e9a636ba79b9e6a693f", features = ["runtime-linking"] }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,5 @@ pedantic = { level = "warn", priority = -1 }
 clap = { version = "4.5.26", features = ["derive"] }
 criterion = "0.5.1"
 miette = { version = "7.2.0", features = ["fancy"] }
-# openvino = { version = "0.8", features = ["runtime-linking"] }
 openvino = { git = "https://github.com/Rickvanderveen/openvino-rs.git", rev = "b590f0fe2467c52b74ef4e9a636ba79b9e6a693f", features = ["runtime-linking"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,6 @@ pedantic = { level = "warn", priority = -1 }
 clap = { version = "4.5.26", features = ["derive"] }
 criterion = "0.5.1"
 miette = { version = "7.2.0", features = ["fancy"] }
-openvino = { git = "https://github.com/Rickvanderveen/openvino-rs.git", rev = "b590f0fe2467c52b74ef4e9a636ba79b9e6a693f", features = ["runtime-linking"] }
-
+openvino = { git = "https://github.com/Rickvanderveen/openvino-rs.git", rev = "b590f0fe2467c52b74ef4e9a636ba79b9e6a693f", features = [
+  "runtime-linking",
+] }


### PR DESCRIPTION
The `openvino-rs` dependency is updated to work with openvino 2025.